### PR TITLE
chore: smol ffi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           if [[ "${{ github.event_name }}" = "release" ]]; then
             echo "flags=--release" >> "$GITHUB_OUTPUT"
           else
-            echo "flags=" >> "$GITHUB_OUTPUT"
+            echo "flags=--release" >> "$GITHUB_OUTPUT"
           fi
 
       # - name: Build mock server CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,16 +77,16 @@ jobs:
             echo "flags=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build mock server CLI
-        if: |
-          github.event_name == 'push' ||
-          github.event_name == 'pull_request' ||
-          startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
-        shell: bash
-        run: |
-          ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
-            ${{ steps.cargo-flags.outputs.flags }}
-        working-directory: rust/pact_mock_server_cli
+      # - name: Build mock server CLI
+      #   if: |
+      #     github.event_name == 'push' ||
+      #     github.event_name == 'pull_request' ||
+      #     startsWith(github.ref, 'refs/tags/pact_mock_server_cli')
+      #   shell: bash
+      #   run: |
+      #     ./release-${{ steps.platform-abbreviation.outputs.platform }}.sh \
+      #       ${{ steps.cargo-flags.outputs.flags }}
+      #   working-directory: rust/pact_mock_server_cli
 
       - name: Build verifier CLI
         if: |

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,4 +17,3 @@ onig = { git = "https://github.com/rust-onig/rust-onig", default-features = fals
 strip = true
 opt-level = "z"
 codegen-units = 1
-lto = true

--- a/rust/pact_ffi/Cargo.toml
+++ b/rust/pact_ffi/Cargo.toml
@@ -68,9 +68,3 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [build-dependencies]
 os_info = { version = "3.7.0", default-features = false }
-
-[profile.release]
-strip = true
-opt-level = "z"
-codegen-units = 1
-lto = true

--- a/rust/pact_ffi/build.rs
+++ b/rust/pact_ffi/build.rs
@@ -1,8 +1,10 @@
+use std::env;
 use os_info::Type;
 
 fn main() {
     let info = os_info::get();
-    if info.os_type() == Type::Macos {
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+    if info.os_type() == Type::Macos && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "macos" {
       // Remove hardcoded path to avoid need to use install_name_tool.
       // Drop file into a well-known path such as /usr/local/lib and it can be automatically discovered
       println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,libpact_ffi.dylib");

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -109,7 +109,7 @@ EOM
             "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.a.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.so.gz"
     fi
 }

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -8,7 +8,7 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
@@ -21,10 +21,10 @@ build_x86_64_gnu() {
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.a.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.so.gz"
     fi
 }
@@ -49,15 +49,15 @@ EOM
         docker run \
             --platform=linux/amd64 \
             --rm \
-            -v "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release:/scratch" \
+            -v "$TARGET_DIR/x86_64-unknown-linux-musl/release:/scratch" \
             alpine \
             /bin/sh -c "$BUILD_SCRIPT"
 
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.a.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.so.gz"
     fi
 }
@@ -73,10 +73,10 @@ build_aarch64_gnu() {
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.a.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.so.gz"
     fi
 }
@@ -101,15 +101,15 @@ EOM
         docker run \
             --platform=linux/arm64 \
             --rm \
-            -v "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release:/scratch" \
+            -v "$TARGET_DIR/aarch64-unknown-linux-musl/release:/scratch" \
             alpine \
             /bin/sh -c "$BUILD_SCRIPT"
 
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.a.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.so.gz"
     fi
 }

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -16,7 +16,7 @@ cargo_flags=( "$@" )
 # Build the x86_64 GNU linux release
 build_x86_64_gnu() {
     install_cross
-    cargo clean
+    # cargo clean
     cross build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -30,9 +30,9 @@ build_x86_64_gnu() {
 }
 
 build_x86_64_musl() {
-    sudo apt-get install -y musl-tools
-    cargo clean
-    cargo build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    # sudo apt-get install -y musl-tools
+    # cargo clean
+    cross build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         BUILD_SCRIPT=$(cat <<EOM
@@ -40,6 +40,8 @@ apk add --no-cache musl-dev gcc && \
 cd /scratch && \
 ar -x libpact_ffi.a && \
 gcc -shared *.o -o libpact_ffi.so && \
+strip libpact_ffi.a && \
+strip libpact_ffi.so && \
 rm -f *.o
 EOM
         )
@@ -66,7 +68,7 @@ install_cross() {
 
 build_aarch64_gnu() {
     install_cross
-    cargo clean
+    # cargo clean
     cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -81,7 +83,7 @@ build_aarch64_gnu() {
 
 build_aarch64_musl() {
     install_cross
-    cargo clean
+    # cargo clean
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -90,6 +92,8 @@ apk add --no-cache musl-dev gcc && \
 cd /scratch && \
 ar -x libpact_ffi.a && \
 gcc -shared *.o -o libpact_ffi.so && \
+strip libpact_ffi.a && \
+strip libpact_ffi.so && \
 rm -f *.o
 EOM
         )

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -8,7 +8,7 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
@@ -17,14 +17,14 @@ cargo_flags=( "$@" )
 build_x86_64_gnu() {
     install_cross
     # cargo clean
-    cross build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
+    cross build --target x86_64-unknown-linux-gnu --target-dir "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.a.gz"
         gzip_and_sum \
-            "$TARGET_DIR/x86_64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64.so.gz"
     fi
 }
@@ -32,7 +32,7 @@ build_x86_64_gnu() {
 build_x86_64_musl() {
     # sudo apt-get install -y musl-tools
     # cargo clean
-    cross build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    cross build --target x86_64-unknown-linux-musl --target-dir "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         BUILD_SCRIPT=$(cat <<EOM
@@ -49,15 +49,15 @@ EOM
         docker run \
             --platform=linux/amd64 \
             --rm \
-            -v "$TARGET_DIR/x86_64-unknown-linux-musl/release:/scratch" \
+            -v "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/release:/scratch" \
             alpine \
             /bin/sh -c "$BUILD_SCRIPT"
 
         gzip_and_sum \
-            "$TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.a.gz"
         gzip_and_sum \
-            "$TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.so.gz"
     fi
 }
@@ -69,14 +69,14 @@ install_cross() {
 build_aarch64_gnu() {
     install_cross
     # cargo clean
-    cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
+    cross build --target aarch64-unknown-linux-gnu --target-dir "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.a" \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.a.gz"
         gzip_and_sum \
-            "$TARGET_DIR/aarch64-unknown-linux-gnu/release/libpact_ffi.so" \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64.so.gz"
     fi
 }
@@ -84,7 +84,7 @@ build_aarch64_gnu() {
 build_aarch64_musl() {
     install_cross
     # cargo clean
-    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+    cross build --target aarch64-unknown-linux-musl --target-dir "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         BUILD_SCRIPT=$(cat <<EOM
@@ -101,15 +101,15 @@ EOM
         docker run \
             --platform=linux/arm64 \
             --rm \
-            -v "$TARGET_DIR/aarch64-unknown-linux-musl/release:/scratch" \
+            -v "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/release:/scratch" \
             alpine \
             /bin/sh -c "$BUILD_SCRIPT"
 
         gzip_and_sum \
-            "$TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.a.gz"
         gzip_and_sum \
-            "$TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.so" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.so.gz"
     fi
 }

--- a/rust/pact_verifier_cli/Cargo.toml
+++ b/rust/pact_verifier_cli/Cargo.toml
@@ -44,9 +44,3 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "tracing-lo
 [dev-dependencies]
 expectest = "0.12.0"
 trycmd = "0.15.0"
-
-[profile.release]
-strip = true
-opt-level = "z"
-codegen-units = 1
-lto = true

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -8,18 +8,18 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
 
 build_x86_64() {
     # sudo apt-get install -y musl-tools
-    cross build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    cross build --target=x86_64-unknown-linux-musl --target-dir "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$TARGET_DIR/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
             "$ARTIFACTS_DIR/pact_verifier_cli-linux-x86_64.gz"
     fi
 }
@@ -30,10 +30,10 @@ install_cross() {
 
 build_aarch64() {
     # install_cross
-    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+    cross build --target aarch64-unknown-linux-musl --target-dir "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl" "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum "$TARGET_DIR/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
+        gzip_and_sum "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
         "$ARTIFACTS_DIR/pact_verifier_cli-linux-aarch64.gz"
     fi
 }

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -8,18 +8,18 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
 
 build_x86_64() {
-    sudo apt-get install -y musl-tools
-    cargo build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    # sudo apt-get install -y musl-tools
+    cross build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
+            "$TARGET_DIR/x86_64-unknown-linux-musl/release/pact_verifier_cli" \
             "$ARTIFACTS_DIR/pact_verifier_cli-linux-x86_64.gz"
     fi
 }
@@ -29,14 +29,14 @@ install_cross() {
 }
 
 build_aarch64() {
-    install_cross
+    # install_cross
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        gzip_and_sum "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
+        gzip_and_sum "$TARGET_DIR/aarch64-unknown-linux-musl/release/pact_verifier_cli" \
         "$ARTIFACTS_DIR/pact_verifier_cli-linux-aarch64.gz"
     fi
 }
-
+install_cross
 build_x86_64
 build_aarch64


### PR DESCRIPTION
- testing building on macos with cross tools (build.rs update to only fire for macos targets)
- drop lto as it inflates *.a and *.dll.lib targets
  - causes 3mb increase in linux verifier cli (pass flag conditionally?)
- build all linux targets with cross
  - attempt to run without cargo clean step to maximise caching potential