### PR TITLE
feat: reduce size of ffi & verifier_cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,7 @@ jobs:
         id: cargo-flags
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" = "release" ]]; then
-            echo "flags=--release" >> "$GITHUB_OUTPUT"
-          else
-            echo "flags=" >> "$GITHUB_OUTPUT"
-          fi
+          echo "flags=--release" >> "$GITHUB_OUTPUT"
 
 
       - name: Build verifier CLI

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -8,15 +8,27 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
+# Create slim builds for release
+RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols" 
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
 
+install_cross() {
+    cargo install cross@0.2.5 --force
+}
+install_cross_latest() {
+    cargo install cross --git https://github.com/cross-rs/cross --force
+}
+# Remove the release/build folder between cross runs to avoid conflicting linker symbol errors
+clean_cargo_release_build() {
+    rm -rf $CARGO_TARGET_DIR/release/build
+}
+
 # Build the x86_64 GNU linux release
 build_x86_64_gnu() {
-    install_cross
-    cargo clean
+    clean_cargo_release_build
     cross build --target x86_64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -29,44 +41,8 @@ build_x86_64_gnu() {
     fi
 }
 
-build_x86_64_musl() {
-    sudo apt-get install -y musl-tools
-    cargo clean
-    cargo build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
-
-    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        BUILD_SCRIPT=$(cat <<EOM
-apk add --no-cache musl-dev gcc && \
-cd /scratch && \
-ar -x libpact_ffi.a && \
-gcc -shared *.o -o libpact_ffi.so && \
-rm -f *.o
-EOM
-        )
-
-        docker run \
-            --platform=linux/amd64 \
-            --rm \
-            -v "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release:/scratch" \
-            alpine \
-            /bin/sh -c "$BUILD_SCRIPT"
-
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
-            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.a.gz"
-        gzip_and_sum \
-            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
-            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.so.gz"
-    fi
-}
-
-install_cross() {
-    cargo install cross@0.2.5
-}
-
 build_aarch64_gnu() {
-    install_cross
-    cargo clean
+    clean_cargo_release_build
     cross build --target aarch64-unknown-linux-gnu "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
@@ -79,28 +55,31 @@ build_aarch64_gnu() {
     fi
 }
 
-build_aarch64_musl() {
-    install_cross
-    cargo clean
-    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+build_x86_64_musl() {
+    clean_cargo_release_build
+    # Set -crt-static, to build dynamic *.so library
+    RUSTFLAGS+="-C target-feature=-crt-static" 
+    cross build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    # Unset -crt-static, to ensure
+    RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
-        BUILD_SCRIPT=$(cat <<EOM
-apk add --no-cache musl-dev gcc && \
-cd /scratch && \
-ar -x libpact_ffi.a && \
-gcc -shared *.o -o libpact_ffi.so && \
-rm -f *.o
-EOM
-        )
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.a" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.a.gz"
+        gzip_and_sum \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/libpact_ffi.so" \
+            "$ARTIFACTS_DIR/libpact_ffi-linux-x86_64-musl.so.gz"
+    fi
+}
 
-        docker run \
-            --platform=linux/arm64 \
-            --rm \
-            -v "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release:/scratch" \
-            alpine \
-            /bin/sh -c "$BUILD_SCRIPT"
+build_aarch64_musl() {
+    clean_cargo_release_build
+    RUSTFLAGS+="-C target-feature=-crt-static" 
+    cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
+    RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
 
+    if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
             "$CARGO_TARGET_DIR/aarch64-unknown-linux-musl/release/libpact_ffi.a" \
             "$ARTIFACTS_DIR/libpact_ffi-linux-aarch64-musl.a.gz"
@@ -122,8 +101,9 @@ build_header() {
         --output "$ARTIFACTS_DIR/pact-cpp.h"
 }
 
+install_cross
 build_x86_64_gnu
-build_x86_64_musl
 build_aarch64_gnu
+build_x86_64_musl
 build_aarch64_musl
 build_header

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols" 
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols" 
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )
@@ -58,10 +58,10 @@ build_aarch64_gnu() {
 build_x86_64_musl() {
     clean_cargo_release_build
     # Set -crt-static, to build dynamic *.so library
-    RUSTFLAGS+="-C target-feature=-crt-static" 
+    export RUSTFLAGS+="-C target-feature=-crt-static" 
     cross build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
     # Unset -crt-static, to ensure
-    RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
+    export RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
@@ -75,9 +75,9 @@ build_x86_64_musl() {
 
 build_aarch64_musl() {
     clean_cargo_release_build
-    RUSTFLAGS+="-C target-feature=-crt-static" 
+    export RUSTFLAGS+="-C target-feature=-crt-static" 
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
-    RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
+    export RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \

--- a/rust/pact_ffi/release-linux.sh
+++ b/rust/pact_ffi/release-linux.sh
@@ -58,7 +58,7 @@ build_aarch64_gnu() {
 build_x86_64_musl() {
     clean_cargo_release_build
     # Set -crt-static, to build dynamic *.so library
-    export RUSTFLAGS+="-C target-feature=-crt-static" 
+    export RUSTFLAGS+=" -C target-feature=-crt-static" 
     cross build --target x86_64-unknown-linux-musl "${cargo_flags[@]}"
     # Unset -crt-static, to ensure
     export RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
@@ -75,7 +75,7 @@ build_x86_64_musl() {
 
 build_aarch64_musl() {
     clean_cargo_release_build
-    export RUSTFLAGS+="-C target-feature=-crt-static" 
+    export RUSTFLAGS+=" -C target-feature=-crt-static" 
     cross build --target aarch64-unknown-linux-musl "${cargo_flags[@]}"
     export RUSTFLAGS="${RUSTFLAGS//-C target-feature=-crt-static}"
 

--- a/rust/pact_ffi/release-macos.sh
+++ b/rust/pact_ffi/release-macos.sh
@@ -8,7 +8,9 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
+# Create slim builds for release
+RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # We target the oldest supported version of macOS.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}

--- a/rust/pact_ffi/release-macos.sh
+++ b/rust/pact_ffi/release-macos.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # We target the oldest supported version of macOS.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}

--- a/rust/pact_ffi/release-win.sh
+++ b/rust/pact_ffi/release-win.sh
@@ -8,7 +8,9 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
+# Create slim builds for release
+RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )

--- a/rust/pact_ffi/release-win.sh
+++ b/rust/pact_ffi/release-win.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )

--- a/rust/pact_verifier_cli/release-linux.sh
+++ b/rust/pact_verifier_cli/release-linux.sh
@@ -28,7 +28,7 @@ clean_cargo_release_build() {
 build_x86_64() {
     # sudo apt-get install -y musl-tools
     clean_cargo_release_build
-    cargo build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
+    cross build --target=x86_64-unknown-linux-musl "${cargo_flags[@]}"
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \

--- a/rust/pact_verifier_cli/release-macos.sh
+++ b/rust/pact_verifier_cli/release-macos.sh
@@ -8,7 +8,9 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
+# Create slim builds for release
+RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # We target the oldest supported version of macOS.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}
@@ -36,10 +38,10 @@ build_aarch64() {
 
     if [[ "${cargo_flags[*]}" =~ "--release" ]]; then
         gzip_and_sum \
-            "$CARGO_TARGET_DIR//aarch64-apple-darwin/release/pact_verifier_cli" \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/pact_verifier_cli" \
             "$ARTIFACTS_DIR/pact_verifier_cli-osx-aarch64.gz"
         gzip_and_sum \
-            "$CARGO_TARGET_DIR//aarch64-apple-darwin/release/pact_verifier_cli" \
+            "$CARGO_TARGET_DIR/aarch64-apple-darwin/release/pact_verifier_cli" \
             "$ARTIFACTS_DIR/pact_verifier_cli-macos-aarch64.gz"
     fi
 }

--- a/rust/pact_verifier_cli/release-macos.sh
+++ b/rust/pact_verifier_cli/release-macos.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # We target the oldest supported version of macOS.
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-12}

--- a/rust/pact_verifier_cli/release-win.sh
+++ b/rust/pact_verifier_cli/release-win.sh
@@ -8,7 +8,9 @@ RUST_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )"
 source "$RUST_DIR/scripts/gzip-and-sum.sh"
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
-export CARGO_TARGET_DIR=${CARO_TARGET_DIR:-"$RUST_DIR/target"}
+export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
+# Create slim builds for release
+RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )

--- a/rust/pact_verifier_cli/release-win.sh
+++ b/rust/pact_verifier_cli/release-win.sh
@@ -10,7 +10,7 @@ ARTIFACTS_DIR=${ARTIFACTS_DIR:-"$RUST_DIR/release_artifacts"}
 mkdir -p "$ARTIFACTS_DIR"
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"$RUST_DIR/target"}
 # Create slim builds for release
-RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
+export RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols ${RUSTFLAGS}"
 
 # All flags passed to this script are passed to cargo.
 cargo_flags=( "$@" )


### PR DESCRIPTION
# Slim libraries and verifier_cli

## Inclusions

1. set `RUSTFLAGS="-C opt-level=z -C codegen-units=1 -C strip=symbols"` to `pact_ffi` and `pact_verifier_cli` during `release-*.sh`

3. set `RUSTFLAGS+="-C target-feature=-crt-static"` for `pact_ffi` musl targets to build `libpact_ffi.so`

4. install_cross_latest from pact_verifier_cli for aarch64-unknown-linux-musl

- failing to build with cross 0.2.5

```
cant find crate for time_macros
/cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.36/src/macros.rs:132:9
 pub use time_macros::time;
```

5. pact_ffi release build - remove only `./target/release/build` folder, during cross runs to avoid linker errors
  - allows for rust caching in gh actions

6. update gh release workflow which runs on pull requests to build in release mode, in order to catch errors earlier. we could update to workflow_dispatch, and indiv targets to better isolate failures earlier, than a tagged release


## Test Runs of consuming libraries

- pact-js-core with `*.a` for musl
  - https://github.com/YOU54F/pact-js-core/actions/runs/9308767408
- pact-js-core with `*.so` for musl
  - https://github.com/YOU54F/pact-js-core/actions/runs/9306189583
- pact-php with `*.so` for musl (fixes loading error encounted in 0.4.20)
  - https://github.com/YOU54F/pact-php/actions/runs/9306079485  
- pact-ruby-ffi
  - https://github.com/YOU54F/pact-ruby-ffi/actions/runs/9306933024
- pact-net 
  - https://github.com/YOU54F/pact-net/actions/runs/9309052235
  
  
## Defects identified

- libpact_ffi 0.4.20 pact_ffi_mock_server_logs are empty, when testing in pact-net
  -  [failing run with 0.4.20](https://github.com/YOU54F/pact-net/actions/runs/9310184405/job/25627331819)
  - [passing run with 0.4.19](https://github.com/YOU54F/pact-net/actions/runs/9310715523)
  - [passing run with 0.4.20](https://github.com/YOU54F/pact-net/actions/runs/9310243190)
    - by changing expection to empty logs


failing step ([link](https://github.com/YOU54F/pact-net/actions/runs/9310184405/job/25627331819#step:8:304))
```
[xUnit.net 00:00:01.54]     PactNet.Tests.Drivers.FfiIntegrationTests.HttpInteraction_v3_CreatesPactFile [FAIL]
[xUnit.net 00:00:01.54]       Did not expect logs to be empty.
[xUnit.net 00:00:01.54]       Stack Trace:
[xUnit.net 00:00:01.54]            at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
[xUnit.net 00:00:01.54]            at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
[xUnit.net 00:00:01.54]            at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
[xUnit.net 00:00:01.54]            at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 POST http://localhost:5000/provider-states - application/json 75
[xUnit.net 00:00:01.55]            at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
[xUnit.net 00:00:01.55]            at FluentAssertions.Execution.AssertionScope.FailWith(String message)
dbug: Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware[0]
      Wildcard detected, all requests with hosts will be allowed.
[xUnit.net 00:00:01.55]            at FluentAssertions.Primitives.StringAssertions`1.NotBeEmpty(String because, Object[] becauseArgs)
[xUnit.net 00:00:01.55]         /home/runner/work/pact-net/pact-net/tests/PactNet.Tests/Drivers/FfiIntegrationTests.cs(73,0): at PactNet.Tests.Drivers.FfiIntegrationTests.HttpInteraction_v3_CreatesPactFile()
```

Cause?

Unknown at the moment, but this is the delta between 0.4.19 & 0.4.20

https://github.com/pact-foundation/pact-reference/compare/libpact_ffi-v0.4.19...libpact_ffi-v0.4.20

last working commit :- https://github.com/pact-foundation/pact-reference/commit/fa2b1d097f1343f5967d664aa3cb03f27992971e
first broken commit :- https://github.com/pact-foundation/pact-reference/commit/f5ad729f8109586f825f2062b81d736f6067109b

Looks related to the migration of pact_mock_server to pact-core-mock-server in a seperate repo. 